### PR TITLE
Update Client.php

### DIFF
--- a/src/MarketplaceWebService/Client.php
+++ b/src/MarketplaceWebService/Client.php
@@ -1048,7 +1048,6 @@ class MarketplaceWebService_Client implements MarketplaceWebService_Interface
     return array (
       CURLOPT_POST => true,
       CURLOPT_USERAGENT => $this->config['UserAgent'],
-      CURLOPT_VERBOSE => true,
       CURLOPT_HEADERFUNCTION => array ($this, 'headerCallback'),
       CURLOPT_RETURNTRANSFER => true,
       CURLOPT_SSL_VERIFYPEER => true,


### PR DESCRIPTION
Could we remove `CURLOPT_VERBOSE `? Currently, it's flooding STDERR output, which should not be the default behavior IMO.